### PR TITLE
Support rspec-rails version to 6.1.0

### DIFF
--- a/jasmine_fixture_builder.gemspec
+++ b/jasmine_fixture_builder.gemspec
@@ -18,11 +18,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.9"
+  spec.add_development_dependency "bundler", "~> 2.4"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "railties"
   spec.add_development_dependency "pry", "~> 0.10.1"
   spec.add_development_dependency "codeclimate-test-reporter", "~> 0.4.7"
 
-  spec.add_dependency "rspec-rails", [">= 3.0", "< 5.0"]
+  spec.add_dependency "rspec-rails", [">= 3.0", "<= 6.1.0"]
 end


### PR DESCRIPTION
Update dependencies to support rspec-rails 6.1